### PR TITLE
Update golangci-lint in CI; remove use of deprecated ioutil package

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -22,7 +22,7 @@ local pipeline(name, steps=[]) = {
   pipeline('Lint', steps=[
     step('lint',
          ['golangci-lint run'],
-         'golangci/golangci-lint:v1.37.1'),
+         'golangci/golangci-lint:v1.50.1'),
   ]),
   pipeline('Test', steps=[
     step('test', ['go test -cover -v ./...']),

--- a/mlapi/client.go
+++ b/mlapi/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -88,7 +87,7 @@ func (c *Client) request(ctx context.Context, method, requestPath string, query 
 		defer resp.Body.Close()
 
 		// read the body (even on non-successful HTTP status codes), as that's what the unit tests expect
-		bodyContents, err = ioutil.ReadAll(resp.Body)
+		bodyContents, err = io.ReadAll(resp.Body)
 
 		// if there was an error reading the body, try again
 		if err != nil {


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16. Since we declare go 1.17 in go.mod
we can remove the usage of the deprecated package and use io directly instead.

This also updates the version of golangci-lint used in CI to a version which
caught this deprecation warning.
