### PR TITLE
Use generics to share a responseWrapper struct

### DIFF
--- a/mlapi/client.go
+++ b/mlapi/client.go
@@ -13,6 +13,13 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+type responseWrapper[T any] struct {
+	Status   string   `json:"status"`
+	Data     T        `json:"data"`
+	Warnings []string `json:"warnings"`
+	Error    string   `json:"error"`
+}
+
 // Client is a Grafana API client.
 type Client struct {
 	config  Config
@@ -55,7 +62,7 @@ func New(baseURL string, cfg Config) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) request(ctx context.Context, method, requestPath string, query url.Values, body io.Reader, responseStruct interface{}) error {
+func (c *Client) request(ctx context.Context, method, requestPath string, query url.Values, body io.Reader, responseStruct any) error {
 	var (
 		req          *http.Request
 		resp         *http.Response

--- a/mlapi/holiday.go
+++ b/mlapi/holiday.go
@@ -56,19 +56,13 @@ type CustomPeriod struct {
 	EndTime time.Time `json:"endTime"`
 }
 
-type holidayResponseWrapper struct {
-	Status string  `json:"status"`
-	Data   Holiday `json:"data"`
-	Error  string  `json:"error"`
-}
-
 // NewHoliday creates a new holiday.
 func (c *Client) NewHoliday(ctx context.Context, holiday Holiday) (Holiday, error) {
 	data, err := json.Marshal(holiday)
 	if err != nil {
 		return Holiday{}, err
 	}
-	result := holidayResponseWrapper{}
+	result := responseWrapper[Holiday]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/holidays", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return Holiday{}, err
@@ -76,16 +70,9 @@ func (c *Client) NewHoliday(ctx context.Context, holiday Holiday) (Holiday, erro
 	return result.Data, err
 }
 
-type holidaysResponseWrapper struct {
-	Status   string    `json:"status"`
-	Data     []Holiday `json:"data"`
-	Warnings []string  `json:"warnings"`
-	Error    string    `json:"error"`
-}
-
 // Holidays fetches all existing holidays.
 func (c *Client) Holidays(ctx context.Context) ([]Holiday, error) {
-	result := holidaysResponseWrapper{}
+	result := responseWrapper[[]Holiday]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/holidays", nil, nil, &result)
 	if err != nil {
 		return []Holiday{}, err
@@ -95,7 +82,7 @@ func (c *Client) Holidays(ctx context.Context) ([]Holiday, error) {
 
 // Holiday fetches an existing holiday.
 func (c *Client) Holiday(ctx context.Context, id string) (Holiday, error) {
-	result := holidayResponseWrapper{}
+	result := responseWrapper[Holiday]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/holidays/"+id, nil, nil, &result)
 	if err != nil {
 		return Holiday{}, err
@@ -113,7 +100,7 @@ func (c *Client) UpdateHoliday(ctx context.Context, holiday Holiday) (Holiday, e
 		return Holiday{}, err
 	}
 
-	result := holidayResponseWrapper{}
+	result := responseWrapper[Holiday]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/holidays/"+id, nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return Holiday{}, err

--- a/mlapi/holiday_test.go
+++ b/mlapi/holiday_test.go
@@ -34,7 +34,7 @@ func TestNewHoliday(t *testing.T) {
 		assert.Equal(t, holiday, parsedHoliday)
 		parsedHoliday.ID = id
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(holidayResponseWrapper{Data: parsedHoliday})
+		_ = enc.Encode(responseWrapper[Holiday]{Data: parsedHoliday})
 	}))
 	defer s.Close()
 
@@ -142,7 +142,7 @@ func TestUpdateHoliday(t *testing.T) {
 		parsedHoliday.ID = id
 		assert.Equal(t, holiday, parsedHoliday)
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(holidayResponseWrapper{Data: parsedHoliday})
+		_ = enc.Encode(responseWrapper[Holiday]{Data: parsedHoliday})
 	}))
 	defer s.Close()
 

--- a/mlapi/job.go
+++ b/mlapi/job.go
@@ -53,13 +53,6 @@ type Job struct {
 	Holidays []string `json:"holidays"`
 }
 
-type jobResponseWrapper struct {
-	Status   string   `json:"status"`
-	Data     Job      `json:"data"`
-	Warnings []string `json:"warnings"`
-	Error    string   `json:"error"`
-}
-
 // NewJob creates a machine learning job and schedules a training.
 func (c *Client) NewJob(ctx context.Context, job Job) (Job, error) {
 	data, err := json.Marshal(job)
@@ -67,7 +60,7 @@ func (c *Client) NewJob(ctx context.Context, job Job) (Job, error) {
 		return Job{}, err
 	}
 
-	result := jobResponseWrapper{}
+	result := responseWrapper[Job]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/jobs", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return Job{}, err
@@ -75,16 +68,9 @@ func (c *Client) NewJob(ctx context.Context, job Job) (Job, error) {
 	return result.Data, nil
 }
 
-type jobsResponseWrapper struct {
-	Status   string   `json:"status"`
-	Data     []Job    `json:"data"`
-	Warnings []string `json:"warnings"`
-	Error    string   `json:"error"`
-}
-
 // Jobs fetches all existing machine learning jobs.
 func (c *Client) Jobs(ctx context.Context) ([]Job, error) {
-	result := jobsResponseWrapper{}
+	result := responseWrapper[[]Job]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/jobs", nil, nil, &result)
 	if err != nil {
 		return []Job{}, err
@@ -94,7 +80,7 @@ func (c *Client) Jobs(ctx context.Context) ([]Job, error) {
 
 // Job fetches an existing machine learning job.
 func (c *Client) Job(ctx context.Context, id string) (Job, error) {
-	result := jobResponseWrapper{}
+	result := responseWrapper[Job]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/jobs/"+id, nil, nil, &result)
 	if err != nil {
 		return Job{}, err
@@ -112,7 +98,7 @@ func (c *Client) UpdateJob(ctx context.Context, job Job) (Job, error) {
 		return Job{}, err
 	}
 
-	result := jobResponseWrapper{}
+	result := responseWrapper[Job]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/jobs/"+id, nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return Job{}, err
@@ -137,17 +123,12 @@ func (c *Client) LinkHolidaysToJob(ctx context.Context, jobID string, holidayIDs
 		return Job{}, err
 	}
 
-	result := jobResponseWrapper{}
+	result := responseWrapper[Job]{}
 	err = c.request(ctx, "PUT", "/manage/api/v1/jobs/"+jobID+"/holidays", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return Job{}, err
 	}
 	return result.Data, err
-}
-
-type forecastJobResponseWrapper struct {
-	Status string                    `json:"status"`
-	Data   backend.QueryDataResponse `json:"data"`
 }
 
 // ForecastParams are parameters used in an ephemeral job prediction.
@@ -187,7 +168,7 @@ func (c *Client) ForecastJob(ctx context.Context, spec ForecastRequest) (backend
 		return backend.QueryDataResponse{}, err
 	}
 
-	result := forecastJobResponseWrapper{}
+	result := responseWrapper[backend.QueryDataResponse]{}
 	err = c.request(ctx, "POST", "/predict/api/v1/forecast", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return backend.QueryDataResponse{}, err

--- a/mlapi/job_test.go
+++ b/mlapi/job_test.go
@@ -33,7 +33,7 @@ func TestNewJob(t *testing.T) {
 		assert.Equal(t, job, parsedJob)
 		parsedJob.ID = id
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(jobResponseWrapper{Data: parsedJob})
+		_ = enc.Encode(responseWrapper[Job]{Data: parsedJob})
 	}))
 	defer s.Close()
 
@@ -107,7 +107,7 @@ func TestUpdateJob(t *testing.T) {
 		parsedJob.ID = id
 		assert.Equal(t, job, parsedJob)
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(jobResponseWrapper{Data: parsedJob})
+		_ = enc.Encode(responseWrapper[Job]{Data: parsedJob})
 	}))
 	defer s.Close()
 

--- a/mlapi/outlier.go
+++ b/mlapi/outlier.go
@@ -47,12 +47,6 @@ type OutlierDetector struct {
 	Algorithm OutlierAlgorithm `json:"algorithm"`
 }
 
-type outlierDetectorResponseWrapper struct {
-	Status string          `json:"status"`
-	Data   OutlierDetector `json:"data"`
-	Error  string          `json:"error"`
-}
-
 // NewOutlierDetector creates an outlier detector.
 func (c *Client) NewOutlierDetector(ctx context.Context, outlier OutlierDetector) (OutlierDetector, error) {
 	data, err := json.Marshal(outlier)
@@ -60,7 +54,7 @@ func (c *Client) NewOutlierDetector(ctx context.Context, outlier OutlierDetector
 		return OutlierDetector{}, err
 	}
 
-	result := outlierDetectorResponseWrapper{}
+	result := responseWrapper[OutlierDetector]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/outliers", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return OutlierDetector{}, err
@@ -68,16 +62,9 @@ func (c *Client) NewOutlierDetector(ctx context.Context, outlier OutlierDetector
 	return result.Data, nil
 }
 
-type outlierDetectorsResponseWrapper struct {
-	Status   string            `json:"status"`
-	Data     []OutlierDetector `json:"data"`
-	Warnings []string          `json:"warnings"`
-	Error    string            `json:"error"`
-}
-
 // OutlierDetectors fetches all existing outlier detectors.
 func (c *Client) OutlierDetectors(ctx context.Context) ([]OutlierDetector, error) {
-	result := outlierDetectorsResponseWrapper{}
+	result := responseWrapper[[]OutlierDetector]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/outliers", nil, nil, &result)
 	if err != nil {
 		return []OutlierDetector{}, err
@@ -87,7 +74,7 @@ func (c *Client) OutlierDetectors(ctx context.Context) ([]OutlierDetector, error
 
 // OutlierDetector fetches an existing outlier detector.
 func (c *Client) OutlierDetector(ctx context.Context, id string) (OutlierDetector, error) {
-	result := outlierDetectorResponseWrapper{}
+	result := responseWrapper[OutlierDetector]{}
 	err := c.request(ctx, "GET", "/manage/api/v1/outliers/"+id, nil, nil, &result)
 	if err != nil {
 		return OutlierDetector{}, err
@@ -105,7 +92,7 @@ func (c *Client) UpdateOutlierDetector(ctx context.Context, outlier OutlierDetec
 		return OutlierDetector{}, err
 	}
 
-	result := outlierDetectorResponseWrapper{}
+	result := responseWrapper[OutlierDetector]{}
 	err = c.request(ctx, "POST", "/manage/api/v1/outliers/"+id, nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return OutlierDetector{}, err

--- a/mlapi/outlier_test.go
+++ b/mlapi/outlier_test.go
@@ -33,7 +33,7 @@ func TestNewOutlierDetector(t *testing.T) {
 		assert.Equal(t, outlier, parsedOutlierDetector)
 		parsedOutlierDetector.ID = id
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(outlierDetectorResponseWrapper{Data: parsedOutlierDetector})
+		_ = enc.Encode(responseWrapper[OutlierDetector]{Data: parsedOutlierDetector})
 	}))
 	defer s.Close()
 
@@ -105,7 +105,7 @@ func TestUpdateOutlierDetector(t *testing.T) {
 		parsedOutlierDetector.ID = id
 		assert.Equal(t, outlier, parsedOutlierDetector)
 		enc := json.NewEncoder(w)
-		_ = enc.Encode(outlierDetectorResponseWrapper{Data: parsedOutlierDetector})
+		_ = enc.Encode(responseWrapper[OutlierDetector]{Data: parsedOutlierDetector})
 	}))
 	defer s.Close()
 


### PR DESCRIPTION
This removes several types that are otherwise duplicated. Ideally request could also be made to take a generic, but because it is a method on a struct we would have to make individual clients for each type which is not worthwhile.