### PR TITLE
Implement alert routes for jobs and outliers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ require (
 	github.com/stretchr/testify v1.9.0
 )
 
-require github.com/grafana/grafana-plugin-sdk-go v0.235.0
+require (
+	github.com/grafana/grafana-plugin-sdk-go v0.235.0
+	github.com/prometheus/common v0.53.0
+)
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
@@ -63,7 +66,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.14.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 // indirect

--- a/mlapi/alert.go
+++ b/mlapi/alert.go
@@ -97,7 +97,7 @@ func (c *Client) NewJobAlert(ctx context.Context, jobID string, alert Alert) (Al
 	}
 
 	result := responseWrapper[Alert]{}
-	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts", jobID), nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts", jobID), nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Alert{}, err
 	}
@@ -135,7 +135,7 @@ func (c *Client) UpdateJobAlert(ctx context.Context, jobID string, alert Alert) 
 	}
 
 	result := responseWrapper[Alert]{}
-	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID), nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID), nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Alert{}, err
 	}
@@ -155,7 +155,7 @@ func (c *Client) NewOutlierAlert(ctx context.Context, outlierID string, alert Al
 	}
 
 	result := responseWrapper[Alert]{}
-	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts", outlierID), nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts", outlierID), nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Alert{}, err
 	}
@@ -193,7 +193,7 @@ func (c *Client) UpdateOutlierAlert(ctx context.Context, outlierID string, alert
 	}
 
 	result := responseWrapper[Alert]{}
-	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", outlierID, alertID), nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", outlierID, alertID), nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Alert{}, err
 	}

--- a/mlapi/alert.go
+++ b/mlapi/alert.go
@@ -1,0 +1,206 @@
+package mlapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/prometheus/common/model"
+)
+
+// AnomalyCondition describes what sort of anomaly an alert should be generated for.
+//
+// It is only used for forecast alerts and is not supported for outlier alerts.
+type AnomalyCondition string
+
+const (
+	// AnomalyConditionHigh alerts when the actual value of a metric is higher than the expected range.
+	AnomalyConditionHigh AnomalyCondition = "high"
+	// AnomalyConditionLow alerts when the actual value of a metric is lower than the expected range.
+	AnomalyConditionLow AnomalyCondition = "low"
+	// AnomalyConditionAny alerts when any anomalous condition is present (too high or too low).
+	AnomalyConditionAny AnomalyCondition = "any"
+)
+
+func (d *AnomalyCondition) UnmarshalJSON(b []byte) error {
+	var value string
+	if err := json.Unmarshal(b, &value); err != nil {
+		return err
+	}
+	switch AnomalyCondition(value) {
+	case AnomalyConditionHigh, AnomalyConditionLow, AnomalyConditionAny:
+		*d = AnomalyCondition(value)
+		return nil
+	default:
+		return fmt.Errorf("unrecognized anomalyCondition: %s", value)
+	}
+}
+
+type NoDataState string
+
+const (
+	NoDataStateOK       = "OK"
+	NoDataStateAlerting = "Alerting"
+	NoDataStateNoData   = "NoData"
+)
+
+func (d *NoDataState) UnmarshalJSON(b []byte) error {
+	var value string
+	if err := json.Unmarshal(b, &value); err != nil {
+		return err
+	}
+	switch AnomalyCondition(value) {
+	case NoDataStateOK, NoDataStateAlerting, NoDataStateNoData:
+		*d = NoDataState(value)
+		return nil
+	case "":
+		*d = NoDataState("")
+		return nil
+	default:
+		return fmt.Errorf("unrecognized noDataState: %s", value)
+	}
+}
+
+type Alert struct {
+	ID string `json:"id,omitempty"`
+
+	// Ttile of the alert, at most 190 characters.
+	Title string `json:"title"`
+	// Whether we look for anomalies that are too low, too high, or both.
+	AnomalyCondition AnomalyCondition `json:"anomalyCondition,omitempty"`
+	// The Prometheus style for clause of an alert.
+	For model.Duration `json:"for"`
+	// Allows a comparison of if the average value over the window is
+	// anomalous, for example `>0.7` would alert if more than 70% of the points
+	// in the window are anomalous according to the anomaly condition.
+	Threshold string `json:"threshold,omitempty"`
+	// Specifying a window will issue a range query instead of an instant query
+	// and average values over that range. Maximum of 12h.
+	Window model.Duration `json:"window"`
+	// Additional labels to add to the alert.
+	Labels map[string]string `json:"labels"`
+	// Annotations to include on an alert, such as severity or a description.
+	Annotations map[string]string `json:"annotations"`
+	// NoDataState allows alerting if no data is found in the query. Empty will
+	// default to OK to match Prometheus behavior.
+	NoDataState NoDataState `json:"noDataConditon"`
+
+	SyncError string `json:"syncError,omitempty"`
+}
+
+// NewJobAlert creates an alert for a job.
+func (c *Client) NewJobAlert(ctx context.Context, jobID string, alert Alert) (Alert, error) {
+	data, err := json.Marshal(alert)
+	if err != nil {
+		return Alert{}, err
+	}
+
+	result := responseWrapper[Alert]{}
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts", jobID), nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// JobAlerts fetches all alerts for a given Job.
+func (c *Client) JobAlerts(ctx context.Context, jobID string) ([]Alert, error) {
+	result := responseWrapper[[]Alert]{}
+	err := c.request(ctx, "GET", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts", jobID), nil, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// JobAlert fetches an existing alert for the given machine learning job.
+func (c *Client) JobAlert(ctx context.Context, jobID, alertID string) (Alert, error) {
+	result := responseWrapper[Alert]{}
+	err := c.request(ctx, "GET", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID), nil, nil, &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// UpdateJobAlert updates the alert for a machine learning job.
+func (c *Client) UpdateJobAlert(ctx context.Context, jobID string, alert Alert) (Alert, error) {
+	alertID := alert.ID
+	// Clear the ID before sending otherwise validation fails.
+	alert.ID = ""
+	data, err := json.Marshal(alert)
+	if err != nil {
+		return Alert{}, err
+	}
+
+	result := responseWrapper[Alert]{}
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID), nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// DeleteJobAlert deletes an alert on a job.
+func (c *Client) DeleteJobAlert(ctx context.Context, jobID, alertID string) error {
+	return c.request(ctx, "DELETE", fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID), nil, nil, nil)
+}
+
+// NewOutlierAlert creates an alert for an outlier detector.
+func (c *Client) NewOutlierAlert(ctx context.Context, outlierID string, alert Alert) (Alert, error) {
+	data, err := json.Marshal(alert)
+	if err != nil {
+		return Alert{}, err
+	}
+
+	result := responseWrapper[Alert]{}
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts", outlierID), nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// OutlierAlerts fetches all alerts for a given Job.
+func (c *Client) OutlierAlerts(ctx context.Context, outlierID string) ([]Alert, error) {
+	result := responseWrapper[[]Alert]{}
+	err := c.request(ctx, "GET", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts", outlierID), nil, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// JobAlert fetches an existing alert for the given outlier detector.
+func (c *Client) OutlierAlert(ctx context.Context, outlierID, alertID string) (Alert, error) {
+	result := responseWrapper[Alert]{}
+	err := c.request(ctx, "GET", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", outlierID, alertID), nil, nil, &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// UpdateJobAlert updates the alert for an outlier detector.
+func (c *Client) UpdateOutlierAlert(ctx context.Context, outlierID string, alert Alert) (Alert, error) {
+	alertID := alert.ID
+	// Clear the ID before sending otherwise validation fails.
+	alert.ID = ""
+	data, err := json.Marshal(alert)
+	if err != nil {
+		return Alert{}, err
+	}
+
+	result := responseWrapper[Alert]{}
+	err = c.request(ctx, "POST", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", outlierID, alertID), nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return Alert{}, err
+	}
+	return result.Data, nil
+}
+
+// DeleteOutlierAlert deletes an alert on an outlier detector.
+func (c *Client) DeleteOutlierAlert(ctx context.Context, outlierID, alertID string) error {
+	return c.request(ctx, "DELETE", fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", outlierID, alertID), nil, nil, nil)
+}

--- a/mlapi/alert_test.go
+++ b/mlapi/alert_test.go
@@ -1,0 +1,298 @@
+package mlapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewJobAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "5218f38f-569b-448f-b81d-578173412195"
+	alert := Alert{}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/manage/api/v1/jobs/"+jobID+"/alerts" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		parsedAlert := Alert{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&parsedAlert)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		assert.Equal(t, alert, parsedAlert)
+		parsedAlert.ID = alertID
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(responseWrapper[Alert]{Data: parsedAlert})
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	returnedAlert, err := c.NewJobAlert(ctx, jobID, alert)
+	require.NoError(t, err)
+	assert.Equal(t, alertID, returnedAlert.ID)
+}
+
+func TestJobAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "5218f38f-569b-448f-b81d-578173412195"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, err := w.Write([]byte(
+			`{"status":"success","data":{"id":"5218f38f-569b-448f-b81d-578173412195","created":"2024-07-02T16:19:39.992Z","modified":"2024-07-02T16:19:39.992Z","createdBy":null,"modifiedBy":null,"title":"test job alert","anomalyCondition":"any","for":"5m","window":"0s","labels":{"foo":"bar"},"annotations":{"description":"Anomaly detected","summary":"Anomaly detected"},"noDataConditon":""}}`,
+		))
+		require.NoError(t, err)
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	alert, err := c.JobAlert(ctx, jobID, alertID)
+	require.NoError(t, err)
+	assert.Equal(t, alertID, alert.ID)
+	assert.Equal(t, "test job alert", alert.Title)
+	assert.Equal(t, AnomalyConditionAny, alert.AnomalyCondition)
+	assert.Equal(t, model.Duration(5*time.Minute), alert.For)
+	assert.Equal(t, map[string]string{
+		"foo": "bar",
+	}, alert.Labels)
+	assert.Equal(t, map[string]string{
+		"description": "Anomaly detected",
+		"summary":     "Anomaly detected",
+	}, alert.Annotations)
+}
+
+func TestUpdateJobAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "5218f38f-569b-448f-b81d-578173412195"
+	alert := Alert{
+		ID: alertID,
+	}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		parsedAlert := Alert{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&parsedAlert)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if parsedAlert.ID != "" {
+			http.Error(w, "id should be empty when updating", http.StatusBadRequest)
+			return
+		}
+		parsedAlert.ID = alertID
+		assert.Equal(t, alert, parsedAlert)
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(responseWrapper[Alert]{Data: parsedAlert})
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	returnedAlert, err := c.UpdateJobAlert(ctx, jobID, alert)
+	require.NoError(t, err)
+	assert.Equal(t, alert, returnedAlert)
+}
+
+func TestDeleteJobAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "5218f38f-569b-448f-b81d-578173412195"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/jobs/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, err := w.Write([]byte("successfully deleted"))
+		require.NoError(t, err)
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	err = c.DeleteJobAlert(ctx, jobID, alertID)
+	require.NoError(t, err)
+}
+
+func TestNewOutlierAlert(t *testing.T) {
+	outlierID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "903a57c2-04cf-4a03-b4aa-54567e981ac0"
+	alert := Alert{}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/manage/api/v1/outliers/"+outlierID+"/alerts" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		parsedAlert := Alert{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&parsedAlert)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		assert.Equal(t, alert, parsedAlert)
+		parsedAlert.ID = alertID
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(responseWrapper[Alert]{Data: parsedAlert})
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	returnedAlert, err := c.NewOutlierAlert(ctx, outlierID, alert)
+	require.NoError(t, err)
+	assert.Equal(t, alertID, returnedAlert.ID)
+}
+
+func TestOutlierAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "903a57c2-04cf-4a03-b4aa-54567e981ac0"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, err := w.Write([]byte(
+			`{"status":"success","data":{"id":"903a57c2-04cf-4a03-b4aa-54567e981ac0","created":"2024-07-02T19:04:56.604Z","modified":"2024-07-02T19:04:56.604Z","createdBy":null,"modifiedBy":null,"title":"test outlier alert","for":"5m","window":"1h","labels":{"foo":"bar"},"annotations":{"description":"Outlier detected","summary":"Outlier detected"},"noDataConditon":""}}`,
+		))
+		require.NoError(t, err)
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	alert, err := c.OutlierAlert(ctx, jobID, alertID)
+	require.NoError(t, err)
+	assert.Equal(t, alertID, alert.ID)
+	assert.Equal(t, "test outlier alert", alert.Title)
+	assert.EqualValues(t, "", alert.AnomalyCondition)
+	assert.EqualValues(t, 5*time.Minute, alert.For)
+	assert.EqualValues(t, time.Hour, alert.Window)
+	assert.Equal(t, map[string]string{
+		"foo": "bar",
+	}, alert.Labels)
+	assert.Equal(t, map[string]string{
+		"description": "Outlier detected",
+		"summary":     "Outlier detected",
+	}, alert.Annotations)
+}
+
+func TestUpdateOutlierAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "903a57c2-04cf-4a03-b4aa-54567e981ac0"
+	alert := Alert{
+		ID: alertID,
+	}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		parsedAlert := Alert{}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&parsedAlert)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if parsedAlert.ID != "" {
+			http.Error(w, "id should be empty when updating", http.StatusBadRequest)
+			return
+		}
+		parsedAlert.ID = alertID
+		assert.Equal(t, alert, parsedAlert)
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(responseWrapper[Alert]{Data: parsedAlert})
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	returnedAlert, err := c.UpdateOutlierAlert(ctx, jobID, alert)
+	require.NoError(t, err)
+	assert.Equal(t, alert, returnedAlert)
+}
+
+func TestDeleteOutlierAlert(t *testing.T) {
+	jobID := "8b154ff8-3d64-4b79-8b26-02b4baeb44e4"
+	alertID := "903a57c2-04cf-4a03-b4aa-54567e981ac0"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != fmt.Sprintf("/manage/api/v1/outliers/%s/alerts/%s", jobID, alertID) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, err := w.Write([]byte("successfully deleted"))
+		require.NoError(t, err)
+	}))
+	defer s.Close()
+
+	c, err := New(s.URL, Config{})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	err = c.DeleteOutlierAlert(ctx, jobID, alertID)
+	require.NoError(t, err)
+}

--- a/mlapi/holiday.go
+++ b/mlapi/holiday.go
@@ -63,7 +63,7 @@ func (c *Client) NewHoliday(ctx context.Context, holiday Holiday) (Holiday, erro
 		return Holiday{}, err
 	}
 	result := responseWrapper[Holiday]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/holidays", nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/holidays", nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Holiday{}, err
 	}
@@ -101,7 +101,7 @@ func (c *Client) UpdateHoliday(ctx context.Context, holiday Holiday) (Holiday, e
 	}
 
 	result := responseWrapper[Holiday]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/holidays/"+id, nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/holidays/"+id, nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Holiday{}, err
 	}

--- a/mlapi/job.go
+++ b/mlapi/job.go
@@ -61,7 +61,7 @@ func (c *Client) NewJob(ctx context.Context, job Job) (Job, error) {
 	}
 
 	result := responseWrapper[Job]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/jobs", nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/jobs", nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Job{}, err
 	}
@@ -99,7 +99,7 @@ func (c *Client) UpdateJob(ctx context.Context, job Job) (Job, error) {
 	}
 
 	result := responseWrapper[Job]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/jobs/"+id, nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/jobs/"+id, nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Job{}, err
 	}
@@ -124,7 +124,7 @@ func (c *Client) LinkHolidaysToJob(ctx context.Context, jobID string, holidayIDs
 	}
 
 	result := responseWrapper[Job]{}
-	err = c.request(ctx, "PUT", "/manage/api/v1/jobs/"+jobID+"/holidays", nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "PUT", "/manage/api/v1/jobs/"+jobID+"/holidays", nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return Job{}, err
 	}
@@ -169,7 +169,7 @@ func (c *Client) ForecastJob(ctx context.Context, spec ForecastRequest) (backend
 	}
 
 	result := responseWrapper[backend.QueryDataResponse]{}
-	err = c.request(ctx, "POST", "/predict/api/v1/forecast", nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/predict/api/v1/forecast", nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return backend.QueryDataResponse{}, err
 	}

--- a/mlapi/outlier.go
+++ b/mlapi/outlier.go
@@ -55,7 +55,7 @@ func (c *Client) NewOutlierDetector(ctx context.Context, outlier OutlierDetector
 	}
 
 	result := responseWrapper[OutlierDetector]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/outliers", nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/outliers", nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return OutlierDetector{}, err
 	}
@@ -93,7 +93,7 @@ func (c *Client) UpdateOutlierDetector(ctx context.Context, outlier OutlierDetec
 	}
 
 	result := responseWrapper[OutlierDetector]{}
-	err = c.request(ctx, "POST", "/manage/api/v1/outliers/"+id, nil, bytes.NewBuffer(data), &result)
+	err = c.request(ctx, "POST", "/manage/api/v1/outliers/"+id, nil, bytes.NewReader(data), &result)
 	if err != nil {
 		return OutlierDetector{}, err
 	}


### PR DESCRIPTION
Add the ability to CRUD ML managed alerts to the client. These alerts require a feature flag to be enabled so not all instances will be able to use them yet and will get a 404 back if they try.